### PR TITLE
Update to fix errors with Kusama metadata

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "devDependencies": {
     "@polkadot/ts": "^0.1.88",
-    "@polkadot/types": "^0.100.0-beta.9",
+    "@polkadot/types": "^0.100.0-beta.10",
     "@types/node": "^12.7.11",
     "@types/nodemailer": "^6.2.2",
     "nodemon": "^1.19.3",
@@ -20,8 +20,8 @@
     "typescript": "^3.7.0"
   },
   "dependencies": {
-    "@polkadot/api": "^0.100.0-beta.9",
-    "@polkadot/api-derive": "^0.100.0-beta.9",
+    "@polkadot/api": "^0.100.0-beta.10",
+    "@polkadot/api-derive": "^0.100.0-beta.10",
     "@types/humanize-duration": "^3.18.0",
     "apollo-server": "^2.9.5",
     "edgeware-node-types": "^1.1.0",


### PR DESCRIPTION
Avoid issue:
```
creating api
2020-01-13 02:34:23        RPC-CORE: getMetadata(at?: BlockHash): Metadata:: createType(Metadata):: Unable to create Enum via index 5, in Blake2_128, Blake2_256, Twox128, Twox256, Twox64Concat
2020-01-13 02:34:23   API/DECORATOR: Error: FATAL: Unable to initialize the API: getMetadata(at?: BlockHash): Metadata:: createType(Metadata):: Unable to create Enum via index 5, in Blake2_128, Blake2_256, Twox128, Twox256, Twox64Concat
    at EventEmitter.constructor._onProviderConnect (/home/davidd/dev/polkalert/packages/server/node_modules/@polkadot/api/base/Init.js:55:23)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```